### PR TITLE
Fix URL validation for tweets

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
 
   // validate tweet url function
   const isValidTweetUrl = (url: string): boolean => {
-    const tweetUrlPattern = /^https?:\/\/(twitter\.com|x\.com)\/\w+\/status\/\d+/i
+    const tweetUrlPattern = /^https?:\/\/(twitter\.com|x\.com)\/[\w]+\/status\/\d+(?:\/)?(?:\?.*)?$/i
     return tweetUrlPattern.test(url.trim())
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 // utility functions for tweet url handling
 
 export function validateTweetUrl(url: string): boolean {
-  const tweetUrlPattern = /^https?:\/\/(twitter\.com|x\.com)\/\w+\/status\/\d+/
+  const tweetUrlPattern = /^https?:\/\/(twitter\.com|x\.com)\/[\w]+\/status\/\d+\/?$/
   return tweetUrlPattern.test(url)
 }
 


### PR DESCRIPTION
## Summary
- improve URL validation logic in utility and client form

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6845af67dfe08323b52f24a454205a3c